### PR TITLE
Make keywords case-sensitive, add special values (true, false, etc.)

### DIFF
--- a/lang-vim.js
+++ b/lang-vim.js
@@ -33,9 +33,9 @@ PR['registerLangHandler'](
             // Keywords
             [PR['PR_KEYWORD'], /^(?:function|endfunction|delfunction|return|call|let|unlet|lockvar|unlockvar|if|endif|else|elseif|while|endwhile|for|in|endfor|continue|break|try|endtry|catch|finally|throw|echo|echon|echohl|echomsg|echoerr|execute|set|setlocal|setglobal|autocmd|augroup|[nvxsoilc]?(?:nore|un)?map(?:clear)?|command)\b!?/],
             // Literal number
-            [PR['PR_LITERAL'], /^\d+|(?v:(?:true|false|none|null))/],
+            [PR['PR_LITERAL'], /^\d+|(?:v:(?:true|false|none|null))/],
             // Identifier
-            [PR['PR_PLAIN'], /^(?:(?:[a-z]|_\w)[\w:]*)/i],
+            [PR['PR_PLAIN'], /^(?:(?:[a-z]|_\w)[\w:#]*)/i],
             // Punctuation
             [PR['PR_PUNCTUATION'], /^[^\s\w\'\"]+/]
         ]

--- a/lang-vim.js
+++ b/lang-vim.js
@@ -31,11 +31,11 @@ PR['registerLangHandler'](
             // Line comment
             [PR['PR_COMMENT'], /^[\"\u2018\u2019][^\r\n\u2028\u2029]*/],
             // Keywords
-            [PR['PR_KEYWORD'], /^(?:function|endfunction|delfunction|return|call|let|unlet|lockvar|unlockvar|if|endif|else|elseif|while|endwhile|for|in|endfor|continue|break|try|endtry|catch|finally|throw|echo|ehon|echohl|echomsg|echoerr|execute|set|autocmd|augroup|[nvxsoilc]?(?:nore)?map|command)\b!?/i],
+            [PR['PR_KEYWORD'], /^(?:function|endfunction|delfunction|return|call|let|unlet|lockvar|unlockvar|if|endif|else|elseif|while|endwhile|for|in|endfor|continue|break|try|endtry|catch|finally|throw|echo|echon|echohl|echomsg|echoerr|execute|set|setlocal|setglobal|autocmd|augroup|[nvxsoilc]?(?:nore|un)?map(?:clear)?|command)\b!?/],
             // Literal number
-            [PR['PR_LITERAL'], /^(?:\d+)/i],
+            [PR['PR_LITERAL'], /^\d+|(?v:(?:true|false|none|null))/],
             // Identifier
-            [PR['PR_PLAIN'], /^(?:(?:[a-z]|_\w)[\w\:]*)/i],
+            [PR['PR_PLAIN'], /^(?:(?:[a-z]|_\w)[\w:]*)/i],
             // Punctuation
             [PR['PR_PUNCTUATION'], /^[^\s\w\'\"]+/]
         ]


### PR DESCRIPTION
- The keywords shouldn't be case-insensitive, `FUNCTION` should not be highlighted like `function`.
- `v:true`, `v:false`, `v:none` and `v:null` are [special](http://vimhelp.appspot.com/eval.txt.html#Special) values, it'd be nice to highlight them. Also removed case-insensitivity for literals.
- Corrected `ehon` to `echon`.
- Added `setlocal`, `setglobal`.
- Added the `unmap` and `mapclear` variants (it will also match `nnoremapclear`, but it's simpler)
